### PR TITLE
增加游戏内断网重连机制

### DIFF
--- a/assets/game_data/screen_info/network_disconnect_dialog.yml
+++ b/assets/game_data/screen_info/network_disconnect_dialog.yml
@@ -1,0 +1,30 @@
+screen_id: network_disconnect_dialog
+screen_name: 断网重连弹窗
+pc_alt: false
+area_list:
+- area_name: 文本-断网提示
+  id_mark: true
+  pc_rect:
+  - 780
+  - 480
+  - 1150
+  - 550
+  text: 与服务器断开连接，请重新登录
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []
+- area_name: 按钮-确认
+  id_mark: false
+  pc_rect:
+  - 950
+  - 630
+  - 1020
+  - 660
+  text: 确认
+  lcs_percent: 0.5
+  template_sub_dir: ''
+  template_id: ''
+  template_match_threshold: 0.7
+  goto_list: []

--- a/src/one_dragon/base/operation/operation.py
+++ b/src/one_dragon/base/operation/operation.py
@@ -18,6 +18,7 @@ from one_dragon.base.screen.screen_area import ScreenArea
 from one_dragon.base.screen.screen_utils import OcrClickResultEnum, FindAreaResultEnum
 from one_dragon.utils import debug_utils, cv2_utils, str_utils
 from one_dragon.utils.i18_utils import coalesce_gt, gt
+from sr_od.operations.reconnect_exception import ReconnectException
 from one_dragon.utils.log_utils import log
 
 
@@ -310,6 +311,12 @@ class Operation(OperationBase):
                         log.info('%s 节点 %s 返回状态 %s', self.display_name, node_name, round_result_status)
                 if self.ctx.is_context_pause:  # 有可能触发暂停的时候仍在执行指令 执行完成后 再次触发暂停回调 保证操作的暂停回调真正生效
                     self._on_pause()
+            except ReconnectException:
+                log.info("检测到断网异常，重新进入游戏")
+                if "打开并进入游戏" in self._node_map:
+                    self._current_node = self._node_map["打开并进入游戏"]
+                    self._reset_status_for_new_node()
+                    continue
             except Exception as e:
                 round_result: OperationRoundResult = self.round_retry('异常')
                 if self.last_screenshot is not None:

--- a/src/sr_od/operations/reconnect_exception.py
+++ b/src/sr_od/operations/reconnect_exception.py
@@ -1,0 +1,3 @@
+class ReconnectException(Exception):
+    """Raised when network disconnect dialog is detected"""
+    pass

--- a/src/sr_od/operations/sr_operation.py
+++ b/src/sr_od/operations/sr_operation.py
@@ -2,8 +2,12 @@ from typing import Optional, Callable
 
 from one_dragon.base.operation.operation import Operation
 from one_dragon.base.operation.operation_base import OperationResult
+from one_dragon.utils import cv2_utils, str_utils
+from one_dragon.base.geometry.rectangle import Rect
+from one_dragon.base.geometry.point import Point
 from sr_od.context.sr_context import SrContext
 from sr_od.operations.enter_game.open_and_enter_game import OpenAndEnterGame
+from sr_od.operations.reconnect_exception import ReconnectException
 
 
 class SrOperation(Operation):
@@ -25,3 +29,17 @@ class SrOperation(Operation):
                            op_callback=op_callback,
                            need_check_game_win=need_check_game_win,
                            op_to_enter_game=op_to_enter_game)
+
+    def screenshot(self):
+        screen = super().screenshot()
+        self._check_reconnect_dialog(screen)
+        return screen
+
+    def _check_reconnect_dialog(self, screen):
+        rect = Rect(780, 480, 1150, 550)
+        part = cv2_utils.crop_image_only(screen, rect)
+        ocr_result_map = self.ctx.ocr.run_ocr(part)
+        for text in ocr_result_map.keys():
+            if str_utils.find_by_lcs('与服务器断开连接，请重新登录', text, percent=0.6):
+                self.ctx.controller.click(Point(985, 645))
+                raise ReconnectException()


### PR DESCRIPTION
网络连接极度不稳定时可能弹窗与服务器连接中断，此时需要点击确认并重启游戏，该改动由codex完成。
测试可以正常识别弹窗并重新运行任务，暂未测试出其他问题。
日志如下：
正在加载OCR模型
加载OCR模型完毕
请先结束其他运行中的功能 再启动
指令[ 每日实训 ] 节点 检测游戏窗口 返回状态 成功
指令[ 返回普通大世界 ] 节点 检测游戏窗口 返回状态 成功
...
指令[ 返回普通大世界 ] 节点 画面识别 返回状态 右上角返回
检测到断网异常，重新进入游戏
尝试自动启动游戏 路径为 G:\Program Files\Star Rail\Game\StarRail.exe
命令行指令 cmd /c "start "" "G:\Program Files\Star Rail\Game\StarRail.exe" & exit"
指令[ 打开游戏 ] 节点 打开游戏 返回状态 成功
指令[ 打开游戏 ] 执行成功 返回状态 成功
指令[ 打开并登录游戏 ] 节点 打开游戏 返回状态 成功
指令[ 打开并登录游戏 ] 节点 等待游戏打开 返回状态 成功
指令[ 进入游戏 ] 节点 检测游戏窗口 返回状态 成功
指令[ 进入游戏 ] 节点 画面识别 返回状态 重试
...
指令[ 进入游戏 ] 节点 画面识别 返回状态 重试
指令[ 进入游戏 ] 节点 画面识别 返回状态 文本-开始游戏
指令[ 进入游戏 ] 节点 画面识别 返回状态 重试
...
指令[ 进入游戏 ] 节点 画面识别 返回状态 重试
指令[ 进入游戏 ] 节点 画面识别 返回状态 文本-点击进入
指令[ 返回普通大世界 ] 节点 检测游戏窗口 返回状态 成功
指令[ 返回普通大世界 ] 节点 画面识别 返回状态 右上角返回
