### PR TITLE
feat: 添加新遗器本

### DIFF
--- a/assets/game_data/interastral_peace_guide_data.yml
+++ b/assets/game_data/interastral_peace_guide_data.yml
@@ -389,6 +389,12 @@
       remark_in_game: "遗器"
       show_in_power_plan: true
       mission_list:
+        - mission_name: "隐救之径"
+          show_in_power_plan: true
+          display_name: "再创天地的救世主 自匿星芒的隐士"
+          region_name: "「全世矩阵」无名泰坦大墓"
+          power: 40
+
         - mission_name: "雳涌之径"
           show_in_power_plan: true
           display_name: "烈阳惊雷的女武神 恶海逐波的船长"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 在“侵蚀隧洞”新增任务“隐救之径”（显示名：再创天地的救世主 自匿星芒的隐士），位于“「全世矩阵」无名泰坦大墓”，支持在能量规划中显示，推荐战力40。玩家可在指引中浏览与追踪该任务。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->